### PR TITLE
Small fixes

### DIFF
--- a/lua/xwarn/commands/sv_warn.lua
+++ b/lua/xwarn/commands/sv_warn.lua
@@ -28,7 +28,7 @@ xAdmin.Core.RegisterCommand("warn", "Warn a user", 30, function(admin, args)
 	end
 
 	xWarn.Database.CreateWarn(target, (IsValid(targetPly) and targetPly:Name()) or "Unknown", admin:SteamID64(), admin:Name(), reason, nil, function(_, q)
-		xAdmin.Core.Msg({admin, " warned ", ((IsValid(targetPly) and targetPly) or target), " for: ", xWarn.Config.WarnReasonColor, reason})
+		xAdmin.Core.Msg((xWarn.Config.WarnMessageIncludeID) and {admin, " warned ", ((IsValid(targetPly) and targetPly) or target), " for: ", Color(255, 0, 0), reason, color_white, " (", xWarn.Config.WarnMessageIDColor, q:lastInsert(), color_white, ")"} or {admin, " warned ", ((IsValid(targetPly) and targetPly) or target), " for: ", Color(255, 0, 0), reason})
 		hook.Run("xWarnPlayerWarned", target, targetPly, admin, reason)
 	end)
 end)
@@ -49,14 +49,14 @@ xAdmin.Core.RegisterCommand("warns", "View a user's warnings", 30, function(admi
 	end
 
 	xWarn.Database.GetWarns(target, function(warns)
-		if warns == nil then xAdmin.Core.Msg({"This user has no warnings to display."}, user) return end
+		if warns == nil then xAdmin.Core.Msg({"This user has no warnings to display."}, admin) return end
 		for k, v in pairs(warns) do
-			xAdmin.Core.Msg({string.format("%s - \"%s\" (Warned by %s, %s ago.)", v.id, v.reason, v.admin, string.NiceTime(os.time() - v.time))}, user)
+			xAdmin.Core.Msg({string.format("%s - \"%s\" (Warned by %s, %s ago.)", v.id, v.reason, v.admin, string.NiceTime(os.time() - v.time))}, admin)
 			-- Example:
 			-- 1 - "Hi!" (Warned by MilkGames, 12 minutes ago.)
 			-- ID Reason              Admin       Time ago
 		end
-		xAdmin.Core.Msg({table.getn(warns) .. " warnings in total."}, user)
+		xAdmin.Core.Msg({table.getn(warns) .. " warnings in total."}, admin)
 	end)
 end)
 

--- a/lua/xwarn/commands/sv_warn.lua
+++ b/lua/xwarn/commands/sv_warn.lua
@@ -9,14 +9,14 @@ xAdmin.Core.RegisterCommand("warn", "Warn a user", 30, function(admin, args)
 	local target, targetPly = xAdmin.Core.GetID64(args[1], admin)
 
 	if not target then
-		xAdmin.Core.Msg({xAdmin.Config.ColorLog, "[xWarn] ", color_white, "Please provide a valid target. The following was not recognised: " .. args[1]}, admin)
+		xAdmin.Core.Msg({xAdmin.Config.ColorLogText, "Please provide a valid target. The following was not recognised: " .. args[1]}, admin)
 		return
 	end
 
 	local reason = args[2]
 
 	if not reason then 
-		xAdmin.Core.Msg({xAdmin.Config.ColorLog, "[xWarn] ", color_white, "Please provide a reason."}, admin)
+		xAdmin.Core.Msg({xAdmin.Config.ColorLogText, "Please provide a reason."}, admin)
 		return
 	end
 
@@ -28,7 +28,7 @@ xAdmin.Core.RegisterCommand("warn", "Warn a user", 30, function(admin, args)
 	end
 
 	xWarn.Database.CreateWarn(target, (IsValid(targetPly) and targetPly:Name()) or "Unknown", admin:SteamID64(), admin:Name(), reason, nil, function(_, q)
-		xAdmin.Core.Msg({admin, " warned ", ((IsValid(targetPly) and targetPly) or target), " for: ", Color(255, 0, 0), reason, color_white, " (", Color(128, 0, 128), q:lastInsert(), color_white, ")"})
+		xAdmin.Core.Msg({admin, " warned ", ((IsValid(targetPly) and targetPly) or target), " for: ", xWarn.Config.WarnReasonColor, reason})
 		hook.Run("xWarnPlayerWarned", target, targetPly, admin, reason)
 	end)
 end)
@@ -44,19 +44,19 @@ xAdmin.Core.RegisterCommand("warns", "View a user's warnings", 30, function(admi
 	local target, targetPly = xAdmin.Core.GetID64(args[1], admin)
 
 	if not target then
-		xAdmin.Core.Msg({xAdmin.Config.ColorLog, "[xWarn] ", color_white, "Please provide a valid target. The following was not recognised: " .. args[1]}, admin)
+		xAdmin.Core.Msg({xAdmin.Config.ColorLogText, "Please provide a valid target. The following was not recognised: " .. args[1]}, admin)
 		return
 	end
 
 	xWarn.Database.GetWarns(target, function(warns)
-		if warns == nil then xWarn.msg("You have no warnings!", user) return end
+		if warns == nil then xAdmin.Core.Msg({"This user has no warnings to display."}, user) return end
 		for k, v in pairs(warns) do
-			xWarn.msg(string.format("%s - \"%s\" (Warned by %s, %s ago.)", v.id, v.reason, v.admin, string.NiceTime(os.time() - v.time)), admin)
+			xAdmin.Core.Msg({string.format("%s - \"%s\" (Warned by %s, %s ago.)", v.id, v.reason, v.admin, string.NiceTime(os.time() - v.time))}, user)
 			-- Example:
 			-- 1 - "Hi!" (Warned by MilkGames, 12 minutes ago.)
 			-- ID Reason              Admin       Time ago
 		end
-		xWarn.msg(table.getn(warns) .. " warnings in total.", admin)
+		xAdmin.Core.Msg({table.getn(warns) .. " warnings in total."}, user)
 	end)
 end)
 
@@ -65,14 +65,14 @@ end)
 --- #
 xAdmin.Core.RegisterCommand("mywarns", "View your warnings", 0, function(user)
 	xWarn.Database.GetWarns(user:SteamID64(), function(warns)
-		if warns == nil then xWarn.msg("You have no warnings!", user) return end 
+		if warns == nil then xAdmin.Core.Msg({"You have no warnings to display."}, user) return end 
 		for k, v in pairs(warns) do
-			xWarn.msg(string.format("%s - \"%s\" (Warned by %s, %s ago.)", v.id, v.reason, v.admin, string.NiceTime(os.time() - v.time)), user)
+			xAdmin.Core.Msg({string.format("%s - \"%s\" (Warned by %s, %s ago.)", v.id, v.reason, v.admin, string.NiceTime(os.time() - v.time))}, user)
 			-- Example:
 			-- 1 - "Hi!" (Warned by MilkGames, 12 minutes ago.)
 			-- ID Reason              Admin       Time ago
 		end
-		xWarn.msg(table.getn(warns) .. " warnings in total.", user)
+		xAdmin.Core.Msg({table.getn(warns) .. " warnings in total."}, user)
 	end)
 end)
 
@@ -84,21 +84,21 @@ xAdmin.Core.RegisterCommand("deletewarn", "Delete a warning (by ID)", 40, functi
 		return
 	end
 	if (not tonumber(args[1])) then
-		xAdmin.Core.Msg({Color(46, 170, 200), "[xWarn] ", color_white, "'" .. args[1] .. "' is not an ID. Please provide a valid ID."}, admin)
+		xAdmin.Core.Msg({xAdmin.Config.ColorLogText, "'" .. args[1] .. "' is not an ID. Please provide a valid ID."}, admin)
 		return
 	end
 	xWarn.Database.GetWarnById(args[1], function(warn)
 		if warn and warn[1] then
 			local canDelete, msg = hook.Run("xWarnCanDeleteWarning", admin, warn[1])
 			if canDelete == false then
-				xAdmin.Core.Msg({Color(46, 170, 200), "[xWarn] ", color_white, msg}, admin)
+				xAdmin.Core.Msg({xAdmin.Config.ColorLogText, color_white, msg}, admin)
 				return
 			end
 			xWarn.Database.DestroyWarn(args[1])
 			xAdmin.Core.Msg({admin, " deleted warning with ID ", args[1]})
 			hook.Run("xWarnWarningDeleted", args[1], admin)
 		else 
-			xAdmin.Core.Msg({Color(46, 170, 200), "[xWarn] ", color_white, "'" .. args[1] .. "' is not a valid ID. Please provide a valid ID."}, admin)
+			xAdmin.Core.Msg({xAdmin.Config.ColorLogText, "'" .. args[1] .. "' is not a valid ID. Please provide a valid ID."}, admin)
 		end
 	end )
 end)

--- a/lua/xwarn/config/sh_config.lua
+++ b/lua/xwarn/config/sh_config.lua
@@ -4,4 +4,6 @@ xWarn.Config.PrintMethod = 2 -- Print method
 -- 2: Console and chat 
 xWarn.Config.WarnOnBan = true
 xWarn.Config.WarnReasonColor = Color(255, 0, 0)
+xWarn.Config.WarnMessageIncludeID = false -- REQUIRES MySQL TO WORK
+xWarn.Config.WarnMessageIDColor = Color(255, 75, 75)
 hook.Run("xWarnLoaded")

--- a/lua/xwarn/config/sh_config.lua
+++ b/lua/xwarn/config/sh_config.lua
@@ -3,4 +3,5 @@ xWarn.Config.PrintMethod = 2 -- Print method
 -- 1: Console only
 -- 2: Console and chat 
 xWarn.Config.WarnOnBan = true
+xWarn.Config.WarnReasonColor = Color(255, 0, 0)
 hook.Run("xWarnLoaded")

--- a/lua/xwarn/core/cl_netmsg.lua
+++ b/lua/xwarn/core/cl_netmsg.lua
@@ -1,7 +1,0 @@
-net.Receive( "xWarnWarningInfo", function( len, pl )
-	if xWarn.Config.PrintMethod == 1 then
-		MsgN(net.ReadString())
-	elseif xWarn.Config.PrintMethod == 2 then
-		chat.AddText(net.ReadString())
-	end
-end )

--- a/lua/xwarn/core/sv_netmsg.lua
+++ b/lua/xwarn/core/sv_netmsg.lua
@@ -1,6 +1,0 @@
-util.AddNetworkString("xWarnWarningInfo")
-function xWarn.msg(msg, target) 
-	net.Start("xWarnWarningInfo")
-	net.WriteString(msg)
-	net.Send(target)
-end


### PR DESCRIPTION
Remove double prefixes with the new xAdmin pr, and use xAdmin.Core.Msg instead of xWarn.msg because it looks better. This also stops it from erroring out when using it on sqlite (specifically when warning someone).

Might require https://github.com/TheXYZNetwork/xAdmin/pull/34